### PR TITLE
Use the custom_variables for datagrid styling

### DIFF
--- a/themesource/datagrid/web/main.scss
+++ b/themesource/datagrid/web/main.scss
@@ -1,3 +1,6 @@
+// Default variables
+@import "../../../theme/web/custom-variables";
+
 @import "datagrid";
 @import "datagrid-filters";
 @import "design-properties";


### PR DESCRIPTION
The datagrid should use the main theme custom_variables like the other core components so that custom styling for the datagrid matches the other core components.